### PR TITLE
Support running on server environments (#199)

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,8 +48,10 @@ const methodMap = [
 ];
 
 const nativeAPI = (() => {
-	if (typeof document === 'undefined') { return false }
-	
+	if (typeof document === 'undefined') {
+		return false
+	}
+
 	const unprefixedMethods = methodMap[0];
 	const returnValue = {};
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const methodMap = [
 
 const nativeAPI = (() => {
 	if (typeof document === 'undefined') {
-		return false
+		return false;
 	}
 
 	const unprefixedMethods = methodMap[0];

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ const methodMap = [
 ];
 
 const nativeAPI = (() => {
+	if (typeof document === 'undefined') { return false }
+	
 	const unprefixedMethods = methodMap[0];
 	const returnValue = {};
 


### PR DESCRIPTION
SSR (server-side rendering) is popular these days. Currently it is difficult to import screenful in SvelteKit because the same code is executed both in the browser and on the server. However, screenfull currently errors if `document` does not exist. Hence, one has to fiddle around to ensure that it is only imported when running in the browser. I assume that this also applies to other SSR solutions like Next.js. 

This PR makes it so that screenfull doesn't error on import if `document` is `undefined`. If run on the server, screenful doesn't do anything of course (but that's fine :).

Until this PR is merged, I can use version 5.2.0 which supported this use case. That said, it'd be nice to see it return in the newest version.

---

Fixes #199