### PR TITLE
remove conditional chaining and nullish coalescing operators for webpack4

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ const nativeAPI = (() => {
 	const returnValue = {};
 
 	for (const methodList of methodMap) {
-		const exitFullscreenMethod = methodList?.[1];
+		const exitFullscreenMethod = methodList && methodList[1];
 		if (exitFullscreenMethod in document) {
 			for (const [index, method] of methodList.entries()) {
 				returnValue[unprefixedMethods[index]] = method;
@@ -144,7 +144,7 @@ Object.defineProperties(screenfull, {
 	},
 	element: {
 		enumerable: true,
-		get: () => document[nativeAPI.fullscreenElement] ?? undefined,
+		get: () => document[nativeAPI.fullscreenElement] != null ? document[nativeAPI.fullscreenElement] : undefined,
 	},
 	isEnabled: {
 		enumerable: true,


### PR DESCRIPTION
Webpack 4 does not support conditional chaining and nullish coalescing operators in npm dependencies because acorn 6 does not support it.
This PR removes these operators.